### PR TITLE
small grammar fix

### DIFF
--- a/lab_manual.tex
+++ b/lab_manual.tex
@@ -181,7 +181,7 @@ our general research approach and lab policies.
     page}; you can use the existing issues to help decide what to
   focus on for own edits if you'd like.  Importantly, be sure to fork the \href{https://github.com/ContextLab/lab-manual}{GitHub
     repository}, make your edits on your personal fork, and submit
-  a pull request with your edits so that everyone can benefit. 
+  a pull request with your edits so that everyone can benefit.
 (You won't be able to view either of the pages linked above until
 you've been added to the lab on GitHub).}Every new lab member should read
 the latest version of this lab manual in detail and reference it later
@@ -201,7 +201,7 @@ commentary on the nearby text.
   the document formatting language in which this manual is written),
   you'll want to \href{https://www.latex-project.org/get/}{download \LaTeX} and take a look at
   \href{https://www.latex-tutorial.com/tutorials/quick-start/}{this
-    ``quick start'' tutorial}.} If you don't understand something you 
+    ``quick start'' tutorial}.} If you don't understand something you
 read in this manual, it is important that you \textit{ask another lab
   member for help}.  Every member of the lab brings their own unique
 knowledge base, training, life experiences, and perspectives.
@@ -237,7 +237,7 @@ way that we think will best allow you to achieve your objectives.
 everything you need to know to do your research projects.  As
 described next, you may not even \textit{know} what you need to know
 to do your projects!  Nevertheless, you need somewhere to start, and
-this is that place.  
+this is that place.
 
 We also maintain a repository of
 \href{https://github.com/ContextLab/CDL-tutorials}{lab tutorials} that
@@ -419,7 +419,7 @@ While there is value to the \textit{italicized} items, we value
   commit, etc.) you have nothing you can show the world for your
   efforts.  Produce research products, even if they're small and
   seemingly insignificant, as often as possible.  You can always
-  improve on an already produced research product.  
+  improve on an already produced research product.
 
   \item The product itself (software, paper, poster,
   presentation, grant) is the primary measure of progress.  Before you've
@@ -614,7 +614,7 @@ mistake may have been in the past-- but the second best time is right now!
 Example scenarios (not an exhaustive list):
 \begin{enumerate}
   \item You've shared a figure, statistic, or other result, and
-    you've realized there's a bug in your code.  
+    you've realized there's a bug in your code.
   \item You tried to collect some data and the experiment crashed or
     yielded corrupted data.
   \item You're re-reading a paper that you shared, and you notice a
@@ -642,7 +642,7 @@ happen immediately after you notice the mistake):
   clear.  Also try Google and/or Stack Exchange.
 \end{enumerate}
 
-\noindent \textit{If you think you might have caught a mistake but aren't 
+\noindent \textit{If you think you might have caught a mistake but aren't
   sure, consult with another lab member! It never hurts to be safe!}
 
 
@@ -690,15 +690,15 @@ these roles on your project:
 
 \item \textbf{Project Coordinator.} The Project Coordinator facilitates
   the agile research process both directly and indirectly. The Project Coordinator:
-\begin{enumerate} 
-\item Help to resolve impediments
-\item Create an environment conducive to team self-organization
-\item Capture empirical data to adjust forecasts (e.g.\ weekly Slack
+\begin{enumerate}
+\item Helps to resolve impediments
+\item Creates an environment conducive to team self-organization
+\item Captures empirical data to adjust forecasts (e.g.\ weekly Slack
   reports summarizing progress)
-\item Shield the team from external interference and distraction to
+\item Shields the team from external interference and distraction to
   keep it ``in the zone''
-\item Enforce timelines
-\item Have no management authority over the team (anyone with authority
+\item Enforces timelines
+\item Has no management authority over the team (anyone with authority
   over the team is by definition not its Project
   Coordinator)
 \item Has a leadership role
@@ -758,19 +758,19 @@ meetings:
   1.5 hour meeting on \textbf{\labmeetingtime}.  The precise
   format of this meeting varies from week to week according to lab
   needs and interests. Attendees: all active lab members.
-  
+
 \item \textbf{Project meetings.}  Several of our collaborative
   projects involve regular coordination with external lab members.
   These are organized on an \textit{ad hoc} basis for each project.
   Attendees: all project team members and any other interested active
-  lab members. 
-  
+  lab members.
+
   \item \textbf{Hackathons.}  We occasionally organize hackathon
     style events whereby spontaneously organized groups work towards
     one or more very short term projects or goals.  These are
     scheduled on an \textit{ad hoc} basis.  Attendees: all interested
     lab members, any interested member of the Dartmouth community, and
-    external collaborators.  
+    external collaborators.
 
 \marginnote{\texttt{NOTE:} Each term, you should sign up for a beginning-of-term or
     end-of-term meeting time with \director~via \href{https://context-lab.youcanbook.me/}{YouCanBook.Me}.}
@@ -780,7 +780,7 @@ meetings:
     meeting slot with \director~to discuss your research
     plans, progress, goals, etc.  It is your responsibility to sign up
     for a slot via \href{https://context-lab.youcanbook.me/}{YouCanBook.Me}.
-    
+
   \marginnote{\texttt{NOTE:} Department talks and colloquia are listed on the \hyperref[sec: scheduling]{PBS Department Events} calendar.}
   \item \textbf{Department talks and colloquia.} Each week the
     Department of Psychological and Brain Sciences invites internal
@@ -815,11 +815,11 @@ meetings:
       attendees: all paid lab members and any other lab members who
       want to participate.
 \end{enumerate}
-  
+
 %\newpage
 \newthought{Getting started in the lab}
 
-\noindent 
+\noindent
 \marginnote{\texttt{TASK:} Create (free) Google, Trello, and GitHub
   accounts.  Send your addresses and/or usernames to \coordinator~
   (cc'ing \director) so that you can be added to the lab groups.  Also
@@ -855,7 +855,7 @@ accomplish various necessary administrative tasks:
   \marginnote{\texttt{TASK:} If you are a senior lab member, request a
     1Password invite from \director.} This platform is used by senior
   lab members to manage secure notes and passwords (e.g.\ shared
-  software licenses, card numbers and chart strings, etc.).  
+  software licenses, card numbers and chart strings, etc.).
 \item \href{http://www.context-lab.com/}{\textbf{Lab website.}}
   \marginnote{\texttt{TASK:} Submit a photograph (of yourself or some
     other picture or image that you want to represent you) and a 2-3
@@ -893,7 +893,7 @@ door when you leave.
 
 \newthought{Starting a new project}
 
-\noindent 
+\noindent
 Our lab uses a number of project management tools and policies to
 promote continuity across projects and lab members.  First, make sure
 that your project doesn't already exist (generally this involves
@@ -905,7 +905,7 @@ The general steps to starting a project are:
 \begin{enumerate}
 
   \item Create a Slack channel or decide on existing channel
-    appropriate for project use. 
+    appropriate for project use.
 \marginnote{\texttt{NOTE:} If you create a new Slack channel for your project, invite \director, \coordinator, and other team members to join.}
   \item Coordinate with \director~to set up a \href{https://get.slack.help/hc/en-us/articles/232289568-GitHub-for-Slack}{GitHub
       for Slack} integration between your project and channel by sending a link to the GitHub repo in the project's Slack channel with a note asking to set up a Slack integration.
@@ -1056,7 +1056,7 @@ official lab attendance policy:
 \item It is your responsibility to provide notice, well in advance, to anyone your absence will
   affect (e.g. \director, \coordinator, people you're scheduled to
   meet with, etc.).  The best way to do this is via email or Slack, along with adding your
-  absence to the 
+  absence to the
   \hyperref[sec: scheduling]{out-of-lab
     calendar}.
 \begin{itemize}
@@ -1149,7 +1149,7 @@ prospective employees. The
 provides a similar suite of services to student employees.  The
 \href{http://www.dartmouth.edu/~ombuds/}{Dartmouth Ombuds Office} also
 provides confidential and informal assistance in resolving concerns
-related to interpersonal issues.  Please also see the 
+related to interpersonal issues.  Please also see the
 \hyperref[sec:interpersonal]{\textit{Ask a question, answer a question} section on resources for resolving interpersonal issues}.
 
 
@@ -1310,7 +1310,7 @@ lab.  \coordinator~can help facilitate these payments.
 
 
 \chapter{Ask a question, answer a question}\label{ch:faq}
-This section contains a log of common issues and errors encountered by lab members, as well as some guidelines on where to seek help with issues that may arise in the lab.  If you encounter an issue you don't know how to resolve right away, this is a good place to begin your efforts. 
+This section contains a log of common issues and errors encountered by lab members, as well as some guidelines on where to seek help with issues that may arise in the lab.  If you encounter an issue you don't know how to resolve right away, this is a good place to begin your efforts.
 \\~\\
 \noindent If you run into a tricky technical issue you think is likely to come up again, consider adding it to the log, and then adding the solution when you resolve it.  Additionally, if you find yourself helping another lab member with a problem you encountered in the past, document the problem and its solution here for future lab members.
 
@@ -1364,7 +1364,7 @@ This section contains a log of common issues and errors encountered by lab membe
 \item You can also post your question in the
   \href{https://context-lab.slack.com/messages/computrons/}{\#computrons}
   channel on Slack.
- 
+
 \item Remember, \href{https://www.google.com/}{Google} and
   \href{https://stackoverflow.com/}{Stack Overflow} are your friends!
   Often other people have encountered (and solved!) similar problems,
@@ -1401,7 +1401,7 @@ This section contains a log of common issues and errors encountered by lab membe
 % \newthought{Compiled problems and solutions}
 
 % \subsection{Testing rooms}
-% This section contains common issues and errors encountered when running subjects in our testing rooms. 
+% This section contains common issues and errors encountered when running subjects in our testing rooms.
 
 
 % \subsection{Git \& GitHub}
@@ -1426,7 +1426,7 @@ Experimental \marginnote{\texttt{TASK:} prior to running any non-lab-member
   verify that (a) your experiment has
   been approved by the IRB and (b) your name is
   specifically listed on the associated protocol.} protocols and IRB approval forms are maintained and
-coordinated through 
+coordinated through
 \href{https://rapport.dartmouth.edu/}{RAPPORT}.  Typically this system
 is accessed directly by \director~or \coordinator, but if you feel you
 need access to RAPPORT then let \director~know.
@@ -1483,7 +1483,7 @@ need access to RAPPORT then let \director~know.
 \item I have submitted one or more edits to the lab manual by making a
   pull request to the
   \href{https://github.com/ContextLab/lab-manual}{GitHub repository}.
-\item I have added or commented on at least one issue on the lab manual's 
+\item I have added or commented on at least one issue on the lab manual's
 \href{https://github.com/ContextLab/lab-manual/issues}{GitHub issues page}.
   \item I have read \href{https://www.sciencemag.org/careers/2018/11/what-can-we-learn-dartmouth}{Leah Somerville's commentary} on speaking
     out in toxic or abusive environments.
@@ -1538,7 +1538,7 @@ need access to RAPPORT then let \director~know.
 \hrulefill & \hrulefill \\
 Signature & Date\\
 \end{tabular}
-   
+
 
 % Citation example \cite{Tufte2001}, notice how the citation is in the margin. This is an example of how to add something to the index at the end of the document.\index{citation}
 
@@ -1548,7 +1548,7 @@ Signature & Date\\
 
 % \section{Figures}
 
-% \lipsum[1] 
+% \lipsum[1]
 
 % \begin{marginfigure}
 % \includegraphics[width=\linewidth]{helix}


### PR DESCRIPTION
The items following "Project Coordinator" should contain verbs for a singular subject since the project coordinator is one person