### PR TITLE
Fixed typo and broken links

### DIFF
--- a/lab_manual.tex
+++ b/lab_manual.tex
@@ -829,7 +829,7 @@ accomplish various necessary administrative tasks:
   \marginnote{\texttt{TASK:} If you've never used GitHub (Git)
     before, please work through these
     \href{https://try.github.io/}{GitHub
-      Tutorials}. You may also find it useful to refer to this \href{https://github.com/ContextLab/lab-manual/tree/master/resources/git-cheatsheet.pdf}{Git cheatsheet} and this \href{https://github.com/ContextLab/lab-manual/tree/master/resources/workflow-of-version-control.pdf}{Git workflow} sheet when using Git/GitHub at first.}  This is used to manage all code, papers, grants,
+      Tutorials}. You may also find it useful to refer to this \href{https://github.com/ContextLab/lab-manual/blob/master/resources/cheatsheets/git-cheatsheet.pdf}{Git cheat sheet} and this \hrefhttps://github.com/ContextLab/lab-manual/blob/master/resources/cheatsheets/workflow-of-version-control.pdf}{Git workflow} sheet when using Git/GitHub at first.}  This is used to manage all code, papers, grants,
   presentations, and posters.  In other words, anything where it'd be
   useful to track multiple versions, anything that we might ultimately
   want to release to the public, and/or anything that multiple lab


### PR DESCRIPTION
On Page 19, task 2, the word "cheatsheet" should be two words--"cheat sheet." Also, the links for "Github cheatsheet" and "Github workflow" gave 404 errors, so I updated the links